### PR TITLE
fix(recebimento): Corrige a exibição do nome do cliente no modal

### DIFF
--- a/js/recebimento.js
+++ b/js/recebimento.js
@@ -744,7 +744,7 @@ class RecebimentoManager {
                 <td class="px-4 py-3 text-sm text-gray-900">${item.codigo || '-'}</td>
                 <td class="px-4 py-3 text-sm text-gray-900">${item.descricao || '-'}</td>
                 <td class="px-4 py-3 text-sm text-gray-900 font-medium">${item.qtdePendenteRecebimento || 0}</td>
-                <td class="px-4 py-3 text-sm text-gray-900">${item.nomeCliente || '-'}</td>
+                <td class="px-4 py-3 text-sm text-gray-900">${item.clienteNome || '-'}</td>
                 <td class="px-4 py-3 text-sm text-gray-900">${item.listaMaterial || '-'}</td>
                 <td class="px-4 py-3 text-sm ${statusColor} font-medium">${statusText}</td>
             `;


### PR DESCRIPTION
Corrige um erro de digitação na propriedade do item de `item.nomeCliente` para `item.clienteNome` na função `preencherTabelaModalFornecedor`.

Isso garante que o nome do cliente seja exibido corretamente na coluna "CLIENTE" do modal de detalhes de entregas, que anteriormente mostrava um hífen.